### PR TITLE
Updates to `winit 0.22.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-winit = {git = "https://github.com/rust-windowing/winit", branch="redraw-requested-2.0"}
+winit = "0.22.2"

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,4 +1,3 @@
-#![feature(async_closure)]
 use winit::{event::WindowEvent, event_loop::EventLoop, window::WindowBuilder};
 use winit_async::{EventAsync as Event, EventLoopAsync};
 
@@ -6,28 +5,30 @@ fn main() {
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
 
-    event_loop.run_async(async move |mut runner| 'main: loop {
-        runner.wait().await;
+    event_loop.run_async(move |mut runner| async move {
+        'main: loop {
+            runner.wait().await;
 
-        let mut recv_events = runner.recv_events().await;
-        while let Some(event) = recv_events.next().await {
-            match event {
-                Event::WindowEvent {
-                    event: WindowEvent::CloseRequested,
-                    ..
-                } => {
-                    break 'main;
+            let mut recv_events = runner.recv_events().await;
+            while let Some(event) = recv_events.next().await {
+                match event {
+                    Event::WindowEvent {
+                        event: WindowEvent::CloseRequested,
+                        ..
+                    } => {
+                        break 'main;
+                    }
+                    _ => println!("{:?}", event),
                 }
-                _ => println!("{:?}", event),
             }
-        }
 
-        window.request_redraw();
+            window.request_redraw();
 
-        let mut redraw_requests = recv_events.redraw_requests().await;
-        while let Some(window_id) = redraw_requests.next().await {
-            println!("redraw {:?}", window_id);
+            let mut redraw_requests = recv_events.redraw_requests().await;
+            while let Some(window_id) = redraw_requests.next().await {
+                println!("redraw {:?}", window_id);
+            }
+            println!();
         }
-        println!();
     })
 }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,39 +1,33 @@
-#![feature(async_await, async_closure)]
-use winit::{
-    event::{WindowEvent},
-    event_loop::EventLoop,
-    window::WindowBuilder,
-};
-use winit_async::{EventLoopAsync, EventAsync as Event};
+#![feature(async_closure)]
+use winit::{event::WindowEvent, event_loop::EventLoop, window::WindowBuilder};
+use winit_async::{EventAsync as Event, EventLoopAsync};
 
 fn main() {
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
 
-    event_loop.run_async(async move |mut runner| {
-        'main: loop {
-            runner.wait().await;
+    event_loop.run_async(async move |mut runner| 'main: loop {
+        runner.wait().await;
 
-            let mut recv_events = runner.recv_events().await;
-            while let Some(event) = recv_events.next().await {
-                match event {
-                    Event::WindowEvent {
-                        event: WindowEvent::CloseRequested,
-                        ..
-                    } => {
-                        break 'main;
-                    },
-                    _ => println!("{:?}", event),
+        let mut recv_events = runner.recv_events().await;
+        while let Some(event) = recv_events.next().await {
+            match event {
+                Event::WindowEvent {
+                    event: WindowEvent::CloseRequested,
+                    ..
+                } => {
+                    break 'main;
                 }
+                _ => println!("{:?}", event),
             }
-
-            window.request_redraw();
-
-            let mut redraw_requests = recv_events.redraw_requests().await;
-            while let Some(window_id) = redraw_requests.next().await {
-                println!("redraw {:?}", window_id);
-            }
-            println!();
         }
+
+        window.request_redraw();
+
+        let mut redraw_requests = recv_events.redraw_requests().await;
+        while let Some(window_id) = redraw_requests.next().await {
+            println!("redraw {:?}", window_id);
+        }
+        println!();
     })
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+use_field_init_shorthand = true
+merge_imports = true
+edition = "2018"

--- a/src/future.rs
+++ b/src/future.rs
@@ -1,8 +1,4 @@
-use crate::{
-    SharedState,
-    EventAsync,
-    WaitCanceledCause,
-};
+use crate::{EventAsync, SharedState, WaitCanceledCause};
 use std::{
     cell::RefCell,
     future::Future,
@@ -17,212 +13,215 @@ use winit::{
 };
 
 #[must_use]
-pub struct WaitFuture<'a, E: 'static>  {
-    pub(crate) shared_state: &'a RefCell<SharedState<E>>,
+pub struct WaitFuture<'a, 'e, E: 'static> {
+    pub(crate) shared_state: &'a RefCell<SharedState<'e, E>>,
 }
 
 #[must_use]
-pub struct WaitUntilFuture<'a, E: 'static> {
+pub struct WaitUntilFuture<'a, 'e, E: 'static> {
     pub(crate) timeout: Instant,
-    pub(crate) shared_state: &'a RefCell<SharedState<E>>,
+    pub(crate) shared_state: &'a RefCell<SharedState<'e, E>>,
 }
 
 #[must_use]
-pub(crate) struct EventReceiverBuilder<'a, E: 'static> {
-    pub(crate) shared_state: &'a RefCell<SharedState<E>>,
+pub(crate) struct EventReceiverBuilder<'a, 'e, E: 'static> {
+    pub(crate) shared_state: &'a RefCell<SharedState<'e, E>>,
 }
 
-pub struct EventReceiver<'a, E: 'static> {
-    pub(crate) shared_state: &'a RefCell<SharedState<E>>,
+pub struct EventReceiver<'a, 'e, E: 'static> {
+    pub(crate) shared_state: &'a RefCell<SharedState<'e, E>>,
 }
 
 #[must_use]
-pub struct PollFuture<'a, E: 'static> {
-    pub(crate) shared_state: &'a RefCell<SharedState<E>>,
+pub struct PollFuture<'a, 'e, E: 'static> {
+    pub(crate) shared_state: &'a RefCell<SharedState<'e, E>>,
     pub(crate) sealed: bool,
 }
 
 #[must_use]
-pub(crate) struct RedrawRequestReceiverBuilder<'a, E: 'static> {
-    pub(crate) shared_state: &'a RefCell<SharedState<E>>,
+pub(crate) struct RedrawRequestReceiverBuilder<'a, 'e, E: 'static> {
+    pub(crate) shared_state: &'a RefCell<SharedState<'e, E>>,
 }
 
-pub struct RedrawRequestReceiver<'a, E: 'static> {
-    pub(crate) shared_state: &'a RefCell<SharedState<E>>,
+pub struct RedrawRequestReceiver<'a, 'e, E: 'static> {
+    pub(crate) shared_state: &'a RefCell<SharedState<'e, E>>,
 }
 
 #[must_use]
-pub struct RedrawRequestFuture<'a, E: 'static> {
-    pub(crate) shared_state: &'a RefCell<SharedState<E>>,
+pub struct RedrawRequestFuture<'a, 'e, E: 'static> {
+    pub(crate) shared_state: &'a RefCell<SharedState<'e, E>>,
     pub(crate) sealed: bool,
 }
 
-impl<E> Future for WaitFuture<'_, E> {
+impl<E> Future for WaitFuture<'_, '_, E> {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, _: &mut Context) -> Poll<()> {
         let mut shared_state = self.shared_state.borrow_mut();
         match shared_state.next_event {
-            Some(Event::NewEvents{..}) => {
-                unsafe{ *shared_state.control_flow.unwrap().as_mut() = ControlFlow::Poll };
+            Some(Event::NewEvents { .. }) => {
+                unsafe { *shared_state.control_flow.unwrap().as_mut() = ControlFlow::Poll };
                 Poll::Ready(())
-            },
+            }
             Some(Event::RedrawEventsCleared) => {
-                unsafe{ *shared_state.control_flow.unwrap().as_mut() = ControlFlow::Wait };
+                unsafe { *shared_state.control_flow.unwrap().as_mut() = ControlFlow::Wait };
                 shared_state.next_event = None;
                 Poll::Pending
-            },
-            Some(Event::WindowEvent{..}) |
-            Some(Event::DeviceEvent{..}) |
-            Some(Event::UserEvent{..}) |
-            Some(Event::MainEventsCleared) |
-            Some(Event::RedrawRequested{..}) => {
+            }
+            Some(Event::WindowEvent { .. })
+            | Some(Event::DeviceEvent { .. })
+            | Some(Event::UserEvent { .. })
+            | Some(Event::MainEventsCleared)
+            | Some(Event::RedrawRequested { .. }) => {
                 shared_state.next_event = None;
                 Poll::Pending
-            },
+            }
             Some(Event::LoopDestroyed) => unreachable!(),
-            Some(Event::Suspended) |
-            Some(Event::Resumed) => unimplemented!(),
-            None => Poll::Pending
+            Some(Event::Suspended) | Some(Event::Resumed) => unimplemented!(),
+            None => Poll::Pending,
         }
     }
 }
 
-impl<E> Future for WaitUntilFuture<'_, E> {
+impl<E> Future for WaitUntilFuture<'_, '_, E> {
     type Output = WaitCanceledCause;
 
     fn poll(self: Pin<&mut Self>, _: &mut Context) -> Poll<WaitCanceledCause> {
         let mut shared_state = self.shared_state.borrow_mut();
         match shared_state.next_event {
             Some(Event::NewEvents(cause)) => {
-                unsafe{ *shared_state.control_flow.unwrap().as_mut() = ControlFlow::Poll };
+                unsafe { *shared_state.control_flow.unwrap().as_mut() = ControlFlow::Poll };
                 Poll::Ready(match cause {
-                    StartCause::ResumeTimeReached{..} => WaitCanceledCause::ResumeTimeReached,
-                    StartCause::WaitCancelled{..} |
-                    StartCause::Poll |
-                    StartCause::Init => WaitCanceledCause::EventsReceived,
+                    StartCause::ResumeTimeReached { .. } => WaitCanceledCause::ResumeTimeReached,
+                    StartCause::WaitCancelled { .. } | StartCause::Poll | StartCause::Init => {
+                        WaitCanceledCause::EventsReceived
+                    }
                 })
-            },
+            }
             Some(Event::RedrawEventsCleared) => {
-                unsafe{ *shared_state.control_flow.unwrap().as_mut() = ControlFlow::WaitUntil(self.timeout) };
+                unsafe {
+                    *shared_state.control_flow.unwrap().as_mut() =
+                        ControlFlow::WaitUntil(self.timeout)
+                };
                 shared_state.next_event = None;
                 Poll::Pending
-            },
-            Some(Event::WindowEvent{..}) |
-            Some(Event::DeviceEvent{..}) |
-            Some(Event::UserEvent{..}) |
-            Some(Event::MainEventsCleared) |
-            Some(Event::RedrawRequested{..}) => {
+            }
+            Some(Event::WindowEvent { .. })
+            | Some(Event::DeviceEvent { .. })
+            | Some(Event::UserEvent { .. })
+            | Some(Event::MainEventsCleared)
+            | Some(Event::RedrawRequested { .. }) => {
                 shared_state.next_event = None;
                 Poll::Pending
-            },
+            }
             Some(Event::LoopDestroyed) => unreachable!(),
-            Some(Event::Suspended) |
-            Some(Event::Resumed) => unimplemented!(),
-            None => Poll::Pending
+            Some(Event::Suspended) | Some(Event::Resumed) => unimplemented!(),
+            None => Poll::Pending,
         }
     }
 }
 
-impl<'el, E> Future for EventReceiverBuilder<'el, E> {
-    type Output = EventReceiver<'el, E>;
-    fn poll(self: Pin<&mut Self>, _: &mut Context) -> Poll<EventReceiver<'el, E>> {
+impl<'el, 'ev, E> Future for EventReceiverBuilder<'el, 'ev, E> {
+    type Output = EventReceiver<'el, 'ev, E>;
+    fn poll(self: Pin<&mut Self>, _: &mut Context) -> Poll<EventReceiver<'el, 'ev, E>> {
         let mut shared_state = self.shared_state.borrow_mut();
         match shared_state.next_event {
-            Some(Event::RedrawRequested{..}) |
-            Some(Event::RedrawEventsCleared) |
-            Some(Event::MainEventsCleared) => {
+            Some(Event::RedrawRequested { .. })
+            | Some(Event::RedrawEventsCleared)
+            | Some(Event::MainEventsCleared) => {
                 shared_state.next_event = None;
                 Poll::Pending
-            },
+            }
             Some(Event::NewEvents(_)) => {
                 shared_state.next_event = None;
                 Poll::Ready(EventReceiver {
                     shared_state: self.shared_state,
                 })
-            },
-            Some(Event::WindowEvent{..}) |
-            Some(Event::DeviceEvent{..}) |
-            Some(Event::UserEvent{..}) |
-            Some(Event::LoopDestroyed) => unreachable!(),
-            Some(Event::Suspended) |
-            Some(Event::Resumed) => unimplemented!(),
-            None => Poll::Pending
+            }
+            Some(Event::WindowEvent { .. })
+            | Some(Event::DeviceEvent { .. })
+            | Some(Event::UserEvent { .. })
+            | Some(Event::LoopDestroyed) => unreachable!(),
+            Some(Event::Suspended) | Some(Event::Resumed) => unimplemented!(),
+            None => Poll::Pending,
         }
     }
 }
 
-impl<'el, E> EventReceiver<'el, E> {
-    pub fn next(&mut self) -> PollFuture<'_, E> {
+impl<'el, 'ev, E> EventReceiver<'el, 'ev, E> {
+    pub fn next(&mut self) -> PollFuture<'_, 'ev, E> {
         PollFuture {
             shared_state: &self.shared_state,
             sealed: false,
         }
     }
 
-    pub fn redraw_requests(self) -> impl Future<Output=RedrawRequestReceiver<'el, E>> {
+    pub fn redraw_requests(self) -> impl Future<Output = RedrawRequestReceiver<'el, 'ev, E>> {
         RedrawRequestReceiverBuilder {
             shared_state: &self.shared_state,
         }
     }
 }
 
-impl<E> Future for PollFuture<'_, E> {
-    type Output = Option<EventAsync<E>>;
+impl<'a, 'ev, E> Future for PollFuture<'a, 'ev, E> {
+    type Output = Option<EventAsync<'ev, E>>;
 
-    fn poll(mut self: Pin<&mut Self>, _: &mut Context) -> Poll<Option<EventAsync<E>>> {
+    fn poll(mut self: Pin<&mut Self>, _: &mut Context) -> Poll<Option<EventAsync<'ev, E>>> {
         if self.sealed {
             return Poll::Ready(None);
         }
 
         let mut shared_state = self.shared_state.borrow_mut();
         match shared_state.next_event.take() {
-            Some(Event::WindowEvent{window_id, event}) => Poll::Ready(Some(EventAsync::WindowEvent{window_id, event})),
-            Some(Event::DeviceEvent{device_id, event}) => Poll::Ready(Some(EventAsync::DeviceEvent{device_id, event})),
+            Some(Event::WindowEvent { window_id, event }) => {
+                Poll::Ready(Some(EventAsync::WindowEvent { window_id, event }))
+            }
+            Some(Event::DeviceEvent { device_id, event }) => {
+                Poll::Ready(Some(EventAsync::DeviceEvent { device_id, event }))
+            }
             Some(Event::UserEvent(event)) => Poll::Ready(Some(EventAsync::UserEvent(event))),
             Some(Event::MainEventsCleared) => {
                 self.sealed = true;
                 Poll::Ready(None)
-            },
-            event @ Some(Event::RedrawRequested{..}) |
-            event @ Some(Event::RedrawEventsCleared) => {
+            }
+            event @ Some(Event::RedrawRequested { .. })
+            | event @ Some(Event::RedrawEventsCleared) => {
                 shared_state.next_event = event;
                 Poll::Ready(None)
-            },
-            Some(Event::NewEvents(_)) |
-            Some(Event::LoopDestroyed) => unreachable!(),
-            Some(Event::Suspended) |
-            Some(Event::Resumed) => unimplemented!(),
-            None => Poll::Pending
+            }
+            Some(Event::NewEvents(_)) | Some(Event::LoopDestroyed) => unreachable!(),
+            Some(Event::Suspended) | Some(Event::Resumed) => unimplemented!(),
+            None => Poll::Pending,
         }
     }
 }
 
-impl<'el, E> Future for RedrawRequestReceiverBuilder<'el, E> {
-    type Output = RedrawRequestReceiver<'el, E>;
-    fn poll(self: Pin<&mut Self>, _: &mut Context) -> Poll<RedrawRequestReceiver<'el, E>> {
+impl<'el, 'ev, E> Future for RedrawRequestReceiverBuilder<'el, 'ev, E> {
+    type Output = RedrawRequestReceiver<'el, 'ev, E>;
+    fn poll(self: Pin<&mut Self>, _: &mut Context) -> Poll<RedrawRequestReceiver<'el, 'ev, E>> {
         let mut shared_state = self.shared_state.borrow_mut();
         match shared_state.next_event {
-            Some(Event::RedrawRequested{..}) |
-            Some(Event::RedrawEventsCleared) => Poll::Ready(RedrawRequestReceiver{shared_state: self.shared_state}),
-            Some(Event::MainEventsCleared) |
-            Some(Event::WindowEvent{..}) |
-            Some(Event::DeviceEvent{..}) |
-            Some(Event::UserEvent{..}) => {
+            Some(Event::RedrawRequested { .. }) | Some(Event::RedrawEventsCleared) => {
+                Poll::Ready(RedrawRequestReceiver {
+                    shared_state: self.shared_state,
+                })
+            }
+            Some(Event::MainEventsCleared)
+            | Some(Event::WindowEvent { .. })
+            | Some(Event::DeviceEvent { .. })
+            | Some(Event::UserEvent { .. }) => {
                 shared_state.next_event = None;
                 Poll::Pending
-            },
-            Some(Event::NewEvents{..}) |
-            Some(Event::LoopDestroyed) => unreachable!(),
-            Some(Event::Suspended) |
-            Some(Event::Resumed) => unimplemented!(),
-            None => Poll::Pending
+            }
+            Some(Event::NewEvents { .. }) | Some(Event::LoopDestroyed) => unreachable!(),
+            Some(Event::Suspended) | Some(Event::Resumed) => unimplemented!(),
+            None => Poll::Pending,
         }
     }
 }
 
-impl<'el, E> RedrawRequestReceiver<'el, E> {
-    pub fn next(&mut self) -> RedrawRequestFuture<'_, E> {
+impl<'el, 'ev, E> RedrawRequestReceiver<'el, 'ev, E> {
+    pub fn next(&mut self) -> RedrawRequestFuture<'_, 'ev, E> {
         RedrawRequestFuture {
             shared_state: &self.shared_state,
             sealed: false,
@@ -230,7 +229,7 @@ impl<'el, E> RedrawRequestReceiver<'el, E> {
     }
 }
 
-impl<'el, E> Future for RedrawRequestFuture<'el, E> {
+impl<'el, 'ev, E> Future for RedrawRequestFuture<'el, 'ev, E> {
     type Output = Option<WindowId>;
 
     fn poll(mut self: Pin<&mut Self>, _: &mut Context) -> Poll<Option<WindowId>> {
@@ -243,24 +242,22 @@ impl<'el, E> Future for RedrawRequestFuture<'el, E> {
             Some(Event::RedrawRequested(window_id)) => {
                 shared_state.next_event = None;
                 Poll::Ready(Some(window_id))
-            },
+            }
             Some(Event::RedrawEventsCleared) => {
                 self.sealed = true;
                 Poll::Ready(None)
-            },
-            Some(Event::WindowEvent{..}) |
-            Some(Event::DeviceEvent{..}) |
-            Some(Event::UserEvent{..}) |
-            Some(Event::MainEventsCleared) => {
+            }
+            Some(Event::WindowEvent { .. })
+            | Some(Event::DeviceEvent { .. })
+            | Some(Event::UserEvent { .. })
+            | Some(Event::MainEventsCleared) => {
                 shared_state.next_event = None;
                 Poll::Pending
-            },
+            }
 
-            Some(Event::NewEvents{..}) |
-            Some(Event::LoopDestroyed) => unreachable!(),
-            Some(Event::Suspended) |
-            Some(Event::Resumed) => unimplemented!(),
-            None => Poll::Pending
+            Some(Event::NewEvents { .. }) | Some(Event::LoopDestroyed) => unreachable!(),
+            Some(Event::Suspended) | Some(Event::Resumed) => unimplemented!(),
+            None => Poll::Pending,
         }
     }
 }


### PR DESCRIPTION
Heya, I've updated the codebase to `winit 0.22.2`. I've tried wiring through the event's lifetime in a0254d6, though it looks like Rust doesn't support getting the closure lifetime to line up with the type:

```rust
$ cargo run --example window                                                                                                                                                                                                                  
   Compiling winit-async v0.1.0 (/mnt/data/work/github/Osspial/winit-async)
error[E0489]: type/lifetime parameter not in scope here
  --> examples/window.rs:8:5
   |
8  | /     event_loop.run_async(move |mut runner| {
9  | |         //
10 | |         async move {
11 | |             'main: loop {
...  |
35 | |         }
36 | |     })
   | |______^
   |
note: the parameter is only valid for the method call at 8:5
  --> examples/window.rs:8:5
   |
8  | /     event_loop.run_async(move |mut runner| {
9  | |         //
10 | |         async move {
11 | |             'main: loop {
...  |
35 | |         }
36 | |     })
   | |______^

error: aborting due to previous error

error: could not compile `winit-async`.
```

I know https://github.com/rust-windowing/winit/pull/1374 is progressing rather quickly, so I can update this to that when it's done.